### PR TITLE
ci: publish Docker image to Docker Hub on merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+jobs:
+  publish:
+    name: Build & Push to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/qa-track
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./app
+          file: ./app/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adiciona workflow `publish.yml` que builda e publica a imagem Docker no Docker Hub automaticamente após merge na `main` ou push de tag `v*`
- Tags geradas: `latest`, SHA curto do commit, versão semântica (`1.2.3`, `1.2`) quando via tag
- Cache do GitHub Actions habilitado para builds mais rápidos

## Secrets necessários

| Secret | Descrição |
|--------|-----------|
| `DOCKERHUB_USERNAME` | Usuário do Docker Hub |
| `DOCKERHUB_TOKEN` | Access token do Docker Hub |

## Test plan

- [ ] Workflow dispara após merge na `main`
- [ ] Imagem publicada com tag `latest` e SHA do commit
- [ ] Workflow **não** dispara em outras branches
- [ ] Tag semântica gerada corretamente ao criar tag `v*`

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)